### PR TITLE
Bump to 1.0.15

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:7.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu May 06 16:17:43 CEST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -3,9 +3,12 @@ apply plugin: 'com.android.application'
 android {
     namespace 'im.crisp.sample'
     compileSdkVersion 33
-    buildToolsVersion "33.0.0"
+    buildToolsVersion "33.0.2"
+
     defaultConfig {
         applicationId "im.crisp.sample"
+        compileSdk 33
+        compileSdkExtension 5
         minSdkVersion 21
         targetSdkVersion 33
         versionCode 1
@@ -22,8 +25,8 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.multidex:multidex:2.0.1'
 
-    implementation 'im.crisp:crisp-sdk:1.0.14'
+    implementation 'im.crisp:crisp-sdk:1.0.15'
 }

--- a/sample/src/lint.xml
+++ b/sample/src/lint.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <!-- Would only be relevant if ExoPlayer's DownloadService was used -->
+    <issue id="NotificationPermission">
+        <ignore regexp="exoplayer.*DownloadService" />
+    </issue>
+</lint>


### PR DESCRIPTION
Changelog is available on GitLab 1.0.15-17 tag.
Be careful, some public API changed their behavior a bit, read the GitLab 1.0.15-17 release to update documentation.